### PR TITLE
Change getChannelId apiURL to twitchtracker.com

### DIFF
--- a/fabric/src/main/java/xeed/mc/streamotes/addon/TwitchEmotesAPI.java
+++ b/fabric/src/main/java/xeed/mc/streamotes/addon/TwitchEmotesAPI.java
@@ -40,24 +40,19 @@ public class TwitchEmotesAPI {
 
 	public static String getChannelId(String name) throws IOException {
 		String channelId = channelToIdMap.get(name);
-		var apiURL = new URL("https://www.twitchmetrics.net/search/channel?q=" + name);
+		var apiURL = new URL("https://twitchtracker.com/" + name);
 
 		try (var reader = new BufferedReader(new InputStreamReader(apiURL.openStream()))) {
 			String data = IOUtils.toString(reader);
-			final String prefix = "<a href=\"/c/";
+			final String prefix = name + ":";
 
 			int ixStart = data.indexOf(prefix);
 			if (ixStart == -1) return channelId;
 
-			int ixEnd = data.indexOf("\"", ixStart + prefix.length());
+			int ixEnd = data.indexOf("</div>", ixStart + prefix.length());
 			if (ixEnd == -1) return channelId;
 
-			String idCode = data.substring(ixStart + prefix.length(), ixEnd);
-
-			ixStart = idCode.indexOf('-');
-			if (ixStart == -1) return channelId;
-
-			channelId = idCode.substring(0, ixStart);
+			channelId = data.substring(ixStart + prefix.length(), ixEnd);
 			channelToIdMap.put(name, channelId);
 			return channelId;
 		}


### PR DESCRIPTION
## Problem:
The problem I got, that plugin didn't show emojis from my account, but showed for "psp1g". After a little investigation, I found out that the problem was with `getChannelId` function. 

It uses TwitchMetrics to get user ID, but the problem is that twitchmetrics doesn't use a twitch database, but a local one. So if you are not registered on the website, it will not show your account. 

## Fix: 
I changed the URL to twitchtracker, since it makes (from my understanding) live requests to twitch, which is more preferable. 