### PR TITLE
fix: many 7tv emotes freezes clients

### DIFF
--- a/fabricbase/src/main/java/xeed/mc/streamotes/emoticon/AsyncEmoticonLoader.java
+++ b/fabricbase/src/main/java/xeed/mc/streamotes/emoticon/AsyncEmoticonLoader.java
@@ -3,20 +3,25 @@ package xeed.mc.streamotes.emoticon;
 import xeed.mc.streamotes.Streamotes;
 import xeed.mc.streamotes.StreamotesCommon;
 
-import java.util.LinkedList;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 public class AsyncEmoticonLoader implements Runnable {
+	private static final int WORKER_COUNT = 4;
+
 	public static final AsyncEmoticonLoader instance = new AsyncEmoticonLoader();
 
-	private final LinkedList<Emoticon> loadQueue;
+	private final Deque<Emoticon> loadQueue;
 	private final Object sync;
 
 	public AsyncEmoticonLoader() {
-		loadQueue = new LinkedList<>();
+		loadQueue = new ArrayDeque<>();
 		sync = new Object();
-		var thread = new Thread(this, "StreamotesLoader");
-		thread.setDaemon(true);
-		thread.start();
+		for (int i = 0; i < WORKER_COUNT; i++) {
+			var thread = new Thread(this, "StreamotesLoader-" + i);
+			thread.setDaemon(true);
+			thread.start();
+		}
 	}
 
 	public void loadAsync(Emoticon emoticon) {
@@ -30,23 +35,24 @@ public class AsyncEmoticonLoader implements Runnable {
 	@Override
 	public void run() {
 		while (true) {
-			try {
-				synchronized (sync) {
-					while (!loadQueue.isEmpty()) {
-						var emoticon = loadQueue.pop();
-						try {
-							emoticon.getLoader().loadEmoticonImage(emoticon);
-
-							Streamotes.log("Loaded emote " + emoticon.getName() + ": W" + emoticon.getWidth() + ", H" + emoticon.getHeight());
-						}
-						catch (Exception e) {
-							StreamotesCommon.loge("Emote " + emoticon.getName() + " load failed", e);
-						}
+			Emoticon emoticon;
+			synchronized (sync) {
+				while (loadQueue.isEmpty()) {
+					try {
+						sync.wait();
 					}
-					sync.wait();
+					catch (InterruptedException ignored) {
+					}
 				}
+				emoticon = loadQueue.pop();
 			}
-			catch (InterruptedException ignored) {
+
+			try {
+				emoticon.getLoader().loadEmoticonImage(emoticon);
+				Streamotes.log("Loaded emote " + emoticon.getName() + ": W" + emoticon.getWidth() + ", H" + emoticon.getHeight());
+			}
+			catch (Exception e) {
+				StreamotesCommon.loge("Emote " + emoticon.getName() + " load failed", e);
 			}
 		}
 	}


### PR DESCRIPTION
#4 still happens for me, when posting many 7tv emotes (especially animated) in one message, the entire client will freeze for quite a while, with more emotes the longer it takes to unfreeze. Some players will fully crash as well.

This PR fixes this by taking the request outside of the `synchronized (sync)` block, while keeping the queue modification within the lock.

Also just added an option to increase the amount of workers that fetch these emotes so more can be fetched in parallel.

**Before:**

https://github.com/user-attachments/assets/db3adf3f-95c3-49e5-bfa9-a5f13fdaa123


**After:**

https://github.com/user-attachments/assets/edf71757-52b4-4358-9fe1-062a69ad7325

