### PR TITLE
fix: many emote request improvements

### DIFF
--- a/fabricbase/src/main/java/xeed/mc/streamotes/Streamotes.java
+++ b/fabricbase/src/main/java/xeed/mc/streamotes/Streamotes.java
@@ -86,14 +86,14 @@ public class Streamotes {
 		}
 	}
 
-	private void startLoadingDaemon(String name, Runnable action) {
+	private void startLoadingDaemon(String name, int loadId, Runnable action) {
 		EmoticonRegistry.startLoading();
 		var thread = new Thread(() -> {
 			try {
 				action.run();
 			}
 			finally {
-				if (EmoticonRegistry.endLoading()) {
+				if (EmoticonRegistry.endLoading() && LOAD_COUNTER.get() == loadId) {
 					var emotes = EmoticonRegistry.getEmoteNames();
 					msg("Finished loading, " + emotes.size() + " emotes from " + getConfig().emoteChannels.size() + " channels");
 				}
@@ -128,8 +128,12 @@ public class Streamotes {
 	private void reloadEmoticons() {
 		final int loadId = LOAD_COUNTER.incrementAndGet();
 
-		startLoadingDaemon("Emote Load Manager", () -> {
-			while (EmoticonRegistry.isLoading()) sleepSweetPrince(10);
+		var thread = new Thread(() -> {
+			while (EmoticonRegistry.isLoading()) {
+				if (LOAD_COUNTER.get() != loadId) return;
+				sleepSweetPrince(10);
+			}
+			if (LOAD_COUNTER.get() != loadId) return;
 
 			EmoticonRegistry.reloadEmoticons();
 			Compat.clearLayerCache();
@@ -161,11 +165,13 @@ public class Streamotes {
 					cfg.twitchGlobalEmotes ? TwitchGlobalPack::loadMetadata : null,
 					cfg.twitchSubscriberEmotes ? TwitchSubscriberPack::loadMetadata : null);
 			}
-		});
+		}, "Emote Load Manager");
+		thread.setDaemon(true);
+		thread.start();
 	}
 
 	public void processPacks(String sourceName, int loadId, ArrayList<String> channelList, Runnable globLoader, Consumer<String> subLoader) {
-		startLoadingDaemon(sourceName + " Emote Loader", () -> {
+		startLoadingDaemon(sourceName + " Emote Loader", loadId, () -> {
 			if (globLoader != null) {
 				try {
 					if (LOAD_COUNTER.get() != loadId) return;

--- a/fabricbase/src/main/java/xeed/mc/streamotes/addon/TwitchEmotesAPI.java
+++ b/fabricbase/src/main/java/xeed/mc/streamotes/addon/TwitchEmotesAPI.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.zip.GZIPInputStream;
 
 public class TwitchEmotesAPI {
 	private static final int CACHE_LIFETIME_IMAGE = 604800000; // 7 days
@@ -67,8 +68,12 @@ public class TwitchEmotesAPI {
 
 	public static InputStream openStream(URL url) throws IOException {
 		var conn = url.openConnection();
+		conn.setConnectTimeout(10000);
+		conn.setReadTimeout(15000);
 		conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0");
-		return conn.getInputStream();
+		conn.setRequestProperty("Accept-Encoding", "gzip");
+		var stream = conn.getInputStream();
+		return "gzip".equalsIgnoreCase(conn.getContentEncoding()) ? new GZIPInputStream(stream) : stream;
 	}
 
 	private static <T> T getJson(InputStream stream, Class<T> cls) throws IOException {
@@ -78,14 +83,17 @@ public class TwitchEmotesAPI {
 	}
 
 	public static <T extends JsonElement> JsonElement getJson(URL url, Class<T> cls) throws IOException {
+		var key = url.toString();
 		synchronized (jsonCache) {
-			var entry = jsonCache.get(url.toString());
-			if (entry != null && entry.expTime() <= System.currentTimeMillis()) return entry.item();
-
-			var json = getJson(openStream(url), cls);
-			jsonCache.put(url.toString(), new CacheEntry<>(json, System.currentTimeMillis() + (1000 * 60)));
-			return json;
+			var entry = jsonCache.get(key);
+			if (entry != null && entry.expTime() > System.currentTimeMillis()) return entry.item();
 		}
+
+		var json = getJson(openStream(url), cls);
+		synchronized (jsonCache) {
+			jsonCache.put(key, new CacheEntry<>(json, System.currentTimeMillis() + (1000 * 60)));
+		}
+		return json;
 	}
 
 	public static JsonObject getJsonObj(URL url) throws IOException {
@@ -100,6 +108,8 @@ public class TwitchEmotesAPI {
 		var apiURL = getURL("https://7tv.io/v3/gql");
 
 		var conn = (HttpURLConnection)apiURL.openConnection();
+		conn.setConnectTimeout(10000);
+		conn.setReadTimeout(15000);
 		conn.setRequestMethod("POST");
 		conn.setRequestProperty("Content-Type", "application/json");
 		conn.setRequestProperty("User-Agent", "insomnia/9.3.3");
@@ -120,42 +130,44 @@ public class TwitchEmotesAPI {
 	public static String getChannelId(String name) throws IOException {
 		synchronized (channelIdCache) {
 			var entry = channelIdCache.get(name);
-			if (entry != null && entry.expTime() <= System.currentTimeMillis()) return entry.item();
+			if (entry != null && entry.expTime() > System.currentTimeMillis()) return entry.item();
+		}
 
-			var conn = makeGQL(name);
-			int code = conn.getResponseCode();
-			if (code / 100 != 2) {
-				String info = IOUtils.toString(conn.getErrorStream(), StandardCharsets.UTF_8);
-				throw new IOException("Channel ID request for name " + name + " returned " + code + ": " + info);
-			}
+		var conn = makeGQL(name);
+		int code = conn.getResponseCode();
+		if (code / 100 != 2) {
+			String info = IOUtils.toString(conn.getErrorStream(), StandardCharsets.UTF_8);
+			throw new IOException("Channel ID request for name " + name + " returned " + code + ": " + info);
+		}
 
-			var data = getJson(conn.getInputStream(), JsonObject.class);
-			try {
-				var users = data.getAsJsonObject("data").getAsJsonArray("users").asList();
-				boolean nameFound = false;
+		var data = getJson(conn.getInputStream(), JsonObject.class);
+		try {
+			var users = data.getAsJsonObject("data").getAsJsonArray("users").asList();
+			boolean nameFound = false;
 
-				for (var uelem : users) {
-					var user = uelem.getAsJsonObject();
-					if (!user.get("username").getAsString().equalsIgnoreCase(name)) continue;
+			for (var uelem : users) {
+				var user = uelem.getAsJsonObject();
+				if (!user.get("username").getAsString().equalsIgnoreCase(name)) continue;
 
-					nameFound = true;
-					var conns = user.getAsJsonArray("connections").asList();
-					for (var celem : conns) {
-						var cdata = celem.getAsJsonObject();
-						if (!cdata.get("platform").getAsString().equals("TWITCH")) continue;
+				nameFound = true;
+				var conns = user.getAsJsonArray("connections").asList();
+				for (var celem : conns) {
+					var cdata = celem.getAsJsonObject();
+					if (!cdata.get("platform").getAsString().equals("TWITCH")) continue;
 
-						var channelId = cdata.get("id").getAsString();
+					var channelId = cdata.get("id").getAsString();
+					synchronized (channelIdCache) {
 						channelIdCache.put(name, new CacheEntry<>(channelId, System.currentTimeMillis() + (1000 * 60 * 5)));
-						return channelId;
 					}
+					return channelId;
 				}
+			}
 
-				if (nameFound) throw new IOException("7tv profile " + name + " has no associated Twitch channel");
-				else throw new IOException("Channel " + name + " has no valid 7tv profile");
-			}
-			catch (NullPointerException | IndexOutOfBoundsException e) {
-				throw new IOException("Invalid json trying to get channel ID of " + name + ": " + data.toString(), e);
-			}
+			if (nameFound) throw new IOException("7tv profile " + name + " has no associated Twitch channel");
+			else throw new IOException("Channel " + name + " has no valid 7tv profile");
+		}
+		catch (NullPointerException | IndexOutOfBoundsException e) {
+			throw new IOException("Invalid json trying to get channel ID of " + name + ": " + data.toString(), e);
 		}
 	}
 

--- a/fabricbase/src/main/java/xeed/mc/streamotes/emoticon/EmoticonRegistry.java
+++ b/fabricbase/src/main/java/xeed/mc/streamotes/emoticon/EmoticonRegistry.java
@@ -26,7 +26,7 @@ public class EmoticonRegistry {
 	}
 
 	public static boolean isLoading() {
-		return loading.get() > 1;
+		return loading.get() > 0;
 	}
 
 	public static List<String> getEmoteNames() {


### PR DESCRIPTION
This PR includes a few request-related improvements in TwitchEmotesAPI, such as:

- Adds timeouts to `openStream` & `makeGQL` to prevent the request from hanging forever in case something is unreachable
- Move some `openStream` calls outside of the `syncrhonize (jsonCache)` lock to prevent long requests from blocking
- Cache check was actually checking if the current time was AFTER expiry, and serves the expired cache
  - Fixed this so stale cache isnt returned, and that when we have fresh cache, it will return that instead of making a whole new request every time
- Use own new thread instead of `startLoadingDaemon` in `reloadEmoticons`

We were having some issues where many users emotes just would not work, we had tried reloading or messing with the mod menu settings to no avail. These changes seem to improve reliability a lot